### PR TITLE
python-thumbor-community-core: review

### DIFF
--- a/python-thumbor-community-core/core-0.3.0/debian/changelog
+++ b/python-thumbor-community-core/core-0.3.0/debian/changelog
@@ -1,4 +1,4 @@
-thumbor-community-core (0.3.0-1) unstable; urgency=low
+python-thumbor-community-core (0.3.0-1) unstable; urgency=low
 
   * First packaging (Closes: #827537)
 

--- a/python-thumbor-community-core/core-0.3.0/debian/control
+++ b/python-thumbor-community-core/core-0.3.0/debian/control
@@ -1,4 +1,4 @@
-Source: thumbor-community-core
+Source: python-thumbor-community-core
 Maintainer: Gilles Dubuc <gilles@wikimedia.org>
 Section: python
 Priority: optional
@@ -12,8 +12,8 @@ Build-Depends: debhelper (>= 9),
                thumbor (>= 6.0.1)
 X-Python-Version: >= 2.6
 Homepage: https://github.com/thumbor-community/core
-Vcs-Git: https://anonscm.debian.org/git/python-modules/packages/thumbor-community-core.git
-Vcs-Browser: https://anonscm.debian.org/cgit/python-modules/packages/thumbor-community-core.git
+Vcs-Git: https://anonscm.debian.org/git/python-modules/packages/python-thumbor-community-core.git
+Vcs-Browser: https://anonscm.debian.org/cgit/python-modules/packages/python-thumbor-community-core.git
 
 Package: python-thumbor-community-core
 Architecture: all

--- a/python-thumbor-community-core/core-0.3.0/debian/docs
+++ b/python-thumbor-community-core/core-0.3.0/debian/docs
@@ -1,1 +1,2 @@
 README.md
+docs

--- a/python-thumbor-community-core/core-0.3.0/debian/python-thumbor-community-core.install
+++ b/python-thumbor-community-core/core-0.3.0/debian/python-thumbor-community-core.install
@@ -1,1 +1,0 @@
-debian/00-community-core.conf etc/thumbor.d

--- a/python-thumbor-community-core/core-0.3.0/debian/rules
+++ b/python-thumbor-community-core/core-0.3.0/debian/rules
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-export PYBUILD_NAME=core
+export PYBUILD_NAME=tc_core
 
 %:
 	dh $@ --with python2 --buildsystem=pybuild


### PR DESCRIPTION
a couple of minor things, though what's left is running `make pyvows_run` during build since it can't get discovered by pybuild